### PR TITLE
Add ARM64/aarch64 and ARM uname to Unix patcher

### DIFF
--- a/WiiLink24PatcherUnix.sh
+++ b/WiiLink24PatcherUnix.sh
@@ -43,6 +43,14 @@ download_patch2(){
 		sys="linux-x64"
 		mount=/mnt
 		;;
+        aarch64,*)
+		sys="(linux-arm64)"
+		mount=/mnt
+		;;
+        *,*)
+		sys="(linux-arm)"
+		mount=/mnt
+		;;
   x86_32,*)
     clear
     header


### PR DESCRIPTION
Allows downloading of ARM64/ARMv8/aarch64 binaries, along with ARM binaries.

Depends on https://github.com/SketchMaster2001/sketchmaster2001.github.io/pull/5 for ARM64.