### PR TITLE
Add Mac M1 uname support

### DIFF
--- a/WiiLink24PatcherUnix.sh
+++ b/WiiLink24PatcherUnix.sh
@@ -35,8 +35,12 @@ download_patch2(){
 
  #System/Architecture Detector
  case $(uname -m),$(uname) in
- 	x86_64,Darwin|arm64,Darwin)
- 		sys="macOS"
+ 	x86_64,Darwin)
+ 		sys="macOS-x64"
+ 		mount=/Volumes
+ 		;;
+        arm64,Darwin)
+ 		sys="macOS-arm64"
  		mount=/Volumes
  		;;
 	x86_64,*)


### PR DESCRIPTION
Depends on https://github.com/SketchMaster2001/sketchmaster2001.github.io/pull/6. **_Will break Mac support if merged before dependent PR's are merged._**

Separates the uname identifier allowing to grab system specific Sharpii files now that M1 support exists in .Net 6.

When merged the dependent repo's Sharpii binaries will also shrink ~66% in size allowing for faster downloads in the patcher.