### PR TITLE
Add dolphin option

### DIFF
--- a/WiiLink-Patcher-CLI/WiiLink_Patcher.cs
+++ b/WiiLink-Patcher-CLI/WiiLink_Patcher.cs
@@ -3200,10 +3200,24 @@ class WiiLink_Patcher
             }
 
             // Please proceed text
-            string pleaseProceed = patcherLang == PatcherLanguage.en
-                ? "Please proceed with the tutorial that you can find on [bold springgreen2_1 link]https://www.wiilink24.com/guide/install/#section-ii---installing-wads-and-patching-mail[/]"
-                : $"{localizedText?["Finished"]?["pleaseProceed"]}";
-            AnsiConsole.MarkupLine($"{pleaseProceed}\n");
+            if ( platformType == Platform.Wii ) {
+                string pleaseProceed = patcherLang == PatcherLanguage.en
+                    ? "Please proceed with the tutorial that you can find on [bold springgreen2_1 link]https://www.wiilink24.com/guide/wii/#section-ii---installing-wads-and-patching-wii-mail[/]"
+                    : $"{localizedText?["Finished"]?["pleaseProceed"]}";
+                AnsiConsole.MarkupLine($"{pleaseProceed}\n");
+            }
+            else if ( platformType == Platform.vWii ) {
+                string pleaseProceed = patcherLang == PatcherLanguage.en
+                    ? "Please proceed with the tutorial that you can find on [bold springgreen2_1 link]https://www.wiilink24.com/guide/vwii/#section-iii---installing-wads-and-patching-wii-mail[/]"
+                    : $"{localizedText?["Finished"]?["pleaseProceed"]}";
+                AnsiConsole.MarkupLine($"{pleaseProceed}\n");
+            }
+            else {
+                string pleaseProceed = patcherLang == PatcherLanguage.en
+                    ? "Please proceed with the tutorial that you can find on [bold springgreen2_1 link]https://www.wiilink24.com/guide/dolphin/#section-ii---installing-wads[/]"
+                    : $"{localizedText?["Finished"]?["pleaseProceed"]}";
+                AnsiConsole.MarkupLine($"{pleaseProceed}\n");
+            }
 
             // What would you like to do now text
             string whatWouldYouLikeToDo = patcherLang == PatcherLanguage.en

--- a/WiiLink-Patcher-CLI/WiiLink_Patcher.cs
+++ b/WiiLink-Patcher-CLI/WiiLink_Patcher.cs
@@ -3185,18 +3185,20 @@ class WiiLink_Patcher
             }
             else
             {
-                // Please connect text
-                string connectDrive = patcherLang == PatcherLanguage.en
-                    ? "Please connect your Wii SD Card / USB Drive and copy the [u]WAD[/] and [u]apps[/] folders to the root (main folder) of your SD Card / USB Drive."
-                    : $"{localizedText?["Finished"]?["withoutSD/USB"]?["connectDrive"]}";
-                AnsiConsole.MarkupLine($"{connectDrive}\n");
+                if (platformType != Platform.Dolphin) {
+                    // Please connect text
+                    string connectDrive = patcherLang == PatcherLanguage.en
+                        ? "Please connect your Wii SD Card / USB Drive and copy the [u]WAD[/] and [u]apps[/] folders to the root (main folder) of your SD Card / USB Drive."
+                        : $"{localizedText?["Finished"]?["withoutSD/USB"]?["connectDrive"]}";
+                    AnsiConsole.MarkupLine($"{connectDrive}\n");
 
-                // Open the folder text
-                string canFindFolders = patcherLang == PatcherLanguage.en
-                    ? "You can find these folders in the [u]{curDir}[/] folder of your computer."
-                    : $"{localizedText?["Finished"]?["canFindFolders"]}";
-                canFindFolders = canFindFolders.Replace("{curDir}", curDir);
-                AnsiConsole.MarkupLine($"{canFindFolders}\n");
+                    // Open the folder text
+                    string canFindFolders = patcherLang == PatcherLanguage.en
+                        ? "You can find these folders in the [u]{curDir}[/] folder of your computer."
+                        : $"{localizedText?["Finished"]?["canFindFolders"]}";
+                    canFindFolders = canFindFolders.Replace("{curDir}", curDir);
+                    AnsiConsole.MarkupLine($"{canFindFolders}\n");
+                }
             }
 
             // Please proceed text

--- a/WiiLink-Patcher-CLI/WiiLink_Patcher.cs
+++ b/WiiLink-Patcher-CLI/WiiLink_Patcher.cs
@@ -14,10 +14,10 @@ using System.IO.Compression;
 class WiiLink_Patcher
 {
     //// Build Info ////
-    static readonly string version = "v2.0.3";
+    static readonly string version = "v2.0.4";
     static readonly string copyrightYear = DateTime.Now.Year.ToString();
-    static readonly string buildDate = "July 6th, 2024";
-    static readonly string buildTime = "11:05 AM";
+    static readonly string buildDate = "October 11th, 2024";
+    static readonly string buildTime = "3:24 PM";
     static string? sdcard = DetectRemovableDrive;
     static readonly string wiiLinkPatcherUrl = "https://patcher.wiilink24.com";
     ////////////////////
@@ -2098,25 +2098,25 @@ class WiiLink_Patcher
         if (platformType != Platform.Dolphin) {
             DownloadOSCApp("AnyGlobe_Changer");
         }
-        else { // Download AnyGlobe_Changer v1.0 from GitHub instead as later releases don't work with Dolphin
+        else if (!Directory.Exists("./apps/AnyGlobe Changer")) { // Download AnyGlobe_Changer v1.0 from GitHub instead as later releases don't work with Dolphin
             task = $"Downloading AnyGlobe_Changer";
             string appPath = Path.Join(tempDir, "AGC");
             Directory.CreateDirectory(appPath);
             DownloadFile($"https://github.com/fishguy6564/AnyGlobe-Changer/releases/download/1.0/AnyGlobe.Changer.zip", Path.Join(appPath, "AGC.zip"), "AnyGlobe_Changer");
             ZipFile.ExtractToDirectory(Path.Join(appPath, "AGC.zip"), "./");
+            Directory.Delete(appPath, true);
         }
 
         // Everybody Votes Channel and Region Select Channel
         DownloadPatch("evc", $"EVC_1_{wc24_reg}.delta", $"EVC_1_{wc24_reg}.delta", "Everybody Votes Channel");
-        //DownloadPatch("RegSel", $"RegSel_1.delta", "RegSel_1.delta", "Region Select");
+        DownloadPatch("RegSel", $"RegSel_1.delta", "RegSel_1.delta", "Region Select");
 
         // Check Mii Out/Mii Contest Channel
         DownloadPatch("cmoc", $"CMOC_1_{wc24_reg}.delta", $"CMOC_1_{wc24_reg}.delta", "Check Mii Out Channel");
 
         // Download ww-43db-patcher for vWii if applicable
-/*         if (platformType == Platform.vWii)
-        {
-            DownloadOSCApp("ww-43db-patcher");
+        if (platformType == Platform.vWii) {
+            // DownloadOSCApp("ww-43db-patcher");
 
             // Also download EULA for each region for vWii users
             string EULATitleID = wc24_reg switch
@@ -2129,7 +2129,7 @@ class WiiLink_Patcher
 
             DownloadWC24Channel("EULA", "EULA", 3, wc24_reg, EULATitleID);
 
-        } */
+        }
 
         if (platformType != Platform.Dolphin) {
         // Install the RC24 Mail Patcher
@@ -2777,17 +2777,17 @@ class WiiLink_Patcher
                 case "evc_us":
                     task = $"Downloading Everybody Votes Channel (USA)";
                     DownloadPatch("evc", $"EVC_1_USA.delta", "EVC_1_USA.delta", "Everybody Votes Channel");
-                    //DownloadPatch("RegSel", "RegSel_1.delta", "RegSel_1.delta", "Region Select");
+                    DownloadPatch("RegSel", "RegSel_1.delta", "RegSel_1.delta", "Region Select");
                     break;
                 case "evc_eu":
                     task = $"Downloading Everybody Votes Channel (PAL)";
                     DownloadPatch("evc", $"EVC_1_PAL.delta", "EVC_1_PAL.delta", "Everybody Votes Channel");
-                    //DownloadPatch("RegSel", "RegSel_1.delta", "RegSel_1.delta", "Region Select");
+                    DownloadPatch("RegSel", "RegSel_1.delta", "RegSel_1.delta", "Region Select");
                     break;
                 case "evc_jp":
                     task = $"Downloading Everybody Votes Channel (Japan)";
                     DownloadPatch("evc", $"EVC_1_Japan.delta", "EVC_1_Japan.delta", "Everybody Votes Channel");
-                    //DownloadPatch("RegSel", "RegSel_1.delta", "RegSel_1.delta", "Region Select");
+                    DownloadPatch("RegSel", "RegSel_1.delta", "RegSel_1.delta", "Region Select");
                     break;
                 case "cmoc_us":
                     task = $"Downloading Check Mii Out Channel (USA)";
@@ -3030,7 +3030,7 @@ class WiiLink_Patcher
         patchingProgress_express["evc"] = "in_progress";
     }
 
-    // Patching Everybody Votes Channel and Region Select
+    // Patching Everybody Votes Channel
     static void EVC_Patch(Region region)
     {
 
@@ -3050,6 +3050,9 @@ class WiiLink_Patcher
         List<string> appNums = ["00000019"];
 
         PatchWC24Channel("evc", $"Everybody Votes Channel", 512, region, channelID, patches, appNums);
+
+        //// Patching Region Select for Everybody Votes Channel
+        RegSel_Patch(region);
 
         // Finished patching Everybody Votes Channel
         patchingProgress_express["evc"] = "done";


### PR DESCRIPTION
Adds a separate dolphin option to the patcher which doesn't download apps for real consoles, and makes sntp conditional to only download on wii. This is my first time working in c# for a while, let me know if anything needs changed!