### PR TITLE
Fix for #149 (Use GitHub if OSCWii is not available)

### DIFF
--- a/WiiLink-Patcher-CLI/patch.cs
+++ b/WiiLink-Patcher-CLI/patch.cs
@@ -8,6 +8,9 @@ using System.Collections.Generic;
 public class PatchClass
 {
 
+    /// <summary>
+    /// Dictionary for GitHub Repositorys in case of OSC not available
+    /// </summary>
     private static readonly Dictionary<string, (string author, string repo)> githubRepos = new()
     {
         { "AnyGlobe_Changer", ("fishguy6564", "AnyGlobe-Changer") },
@@ -26,7 +29,7 @@ public class PatchClass
     {
         MainClass.task = $"Downloading {appName}";
         string appPath = Path.Join("WiiLink", "apps", appName);
-        
+
         if (!Directory.Exists(appPath))
             Directory.CreateDirectory(appPath);
 
@@ -56,6 +59,10 @@ public class PatchClass
         }
     }
 
+    /// <summary>
+    /// Tests if the URL is available
+    /// </summary>
+    /// <param name="url"></param>
     private static bool TestUrl(string url)
     {
         try
@@ -69,6 +76,11 @@ public class PatchClass
         }
     }
     
+    /// <summary>
+    /// Gets the latest GitHub Release
+    /// </summary>
+    /// <param name="author"></param>
+    /// <param name="repo"></param>
     private static string GetLatestGitHubRelease(string author, string repo)
     {
         try
@@ -76,7 +88,12 @@ public class PatchClass
             string apiUrl = $"https://api.github.com/repos/{author}/{repo}/releases";
             MainClass.httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
             var response = MainClass.httpClient.GetStringAsync(apiUrl).Result;
-            var releases = JsonSerializer.Deserialize<List<GitHubRelease>>(response);
+
+            // JSON Deserialisierung mit Optionen, die die Groß-/Kleinschreibung ignorieren
+            var releases = JsonSerializer.Deserialize<List<GitHubRelease>>(response, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
 
             if (releases != null && releases.Count > 0)
             {
@@ -91,6 +108,12 @@ public class PatchClass
         return "";
     }
 
+
+    /// <summary>
+    /// Extracts the required files from the .zip
+    /// </summary>
+    /// <param name="zipFilePath"></param>
+    /// <param name="destination">The destination to save the file to.</param>
     private static void ExtractRequiredFiles(string zipFilePath, string destination)
     {
         using ZipArchive archive = ZipFile.OpenRead(zipFilePath);

--- a/WiiLink-Patcher-CLI/patch.cs
+++ b/WiiLink-Patcher-CLI/patch.cs
@@ -24,6 +24,9 @@ public class PatchClass
     /// <param name="appName"></param>
     public static void DownloadOSCApp(string appName)
     {
+        MainClass.task = $"Downloading {appName}";
+        string appPath = Path.Join("WiiLink", "apps", appName);
+        
         if (!Directory.Exists(appPath))
             Directory.CreateDirectory(appPath);
 

--- a/WiiLink-Patcher-CLI/patch.cs
+++ b/WiiLink-Patcher-CLI/patch.cs
@@ -3,6 +3,7 @@ using libWiiSharp;
 using System.IO.Compression;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 public class PatchClass
@@ -86,14 +87,10 @@ public class PatchClass
         try
         {
             string apiUrl = $"https://api.github.com/repos/{author}/{repo}/releases";
-            MainClass.httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
-            var response = MainClass.httpClient.GetStringAsync(apiUrl).Result;
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
+            var response = httpClient.GetStringAsync(apiUrl).Result;
 
-            // JSON Deserialisierung mit Optionen, die die Groß-/Kleinschreibung ignorieren
-            var releases = JsonSerializer.Deserialize<List<GitHubRelease>>(response, new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            });
+            var releases = JsonSerializer.Deserialize(response, GitHubJsonContext.Default.ListGitHubRelease);
 
             if (releases != null && releases.Count > 0)
             {
@@ -1350,12 +1347,15 @@ public class PatchClass
     }
 }
 
+[JsonSerializable(typeof(List<GitHubRelease>))]
+internal partial class GitHubJsonContext : JsonSerializerContext {}
+
 public class GitHubRelease
 {
-    public List<GitHubAsset> assets { get; set; }
+    public List<GitHubAsset> assets { get; set; } = new();
 }
 
 public class GitHubAsset
 {
-    public string browser_download_url { get; set; }
+    public string browser_download_url { get; set; } = "";
 }

--- a/WiiLink-Patcher-CLI/patch.cs
+++ b/WiiLink-Patcher-CLI/patch.cs
@@ -87,8 +87,8 @@ public class PatchClass
         try
         {
             string apiUrl = $"https://api.github.com/repos/{author}/{repo}/releases";
-            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
-            var response = httpClient.GetStringAsync(apiUrl).Result;
+            MainClass.httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
+            var response = MainClass.httpClient.GetStringAsync(apiUrl).Result;
 
             var releases = JsonSerializer.Deserialize(response, GitHubJsonContext.Default.ListGitHubRelease);
 


### PR DESCRIPTION
Added a simple check if a download from oscwii is available, if not, get the required files from the latest (Pre-)Release directly from GitHub.

(Only tested on a Windows-X64 if working)

Possible fix for #149 
![grafik](https://github.com/user-attachments/assets/6597e093-a2b4-4468-914f-5cd7b1ed470b)
