### PR TITLE
AnyGlobe Changer bug fix

### DIFF
--- a/WiiLink-Patcher-CLI/main.cs
+++ b/WiiLink-Patcher-CLI/main.cs
@@ -12,9 +12,9 @@ using System.Globalization;
 public class MainClass
 {
     //// Build Info ////
-    public static readonly string version = "v2.1.0";
+    public static readonly string version = "v2.1.1";
     public static readonly string copyrightYear = DateTime.Now.Year.ToString();
-    public static readonly DateTime buildDateTime = new DateTime(2025, 3, 26, 15, 30, 00); // Year, Month, Day, Hour, Minute, Second
+    public static readonly DateTime buildDateTime = new DateTime(2025, 4, 14, 10, 56, 35); // Year, Month, Day, Hour, Minute, Second
     public static readonly string buildDate = buildDateTime.ToLongDateString();
     public static readonly string buildTime = buildDateTime.ToShortTimeString();
     public static string? sdcard = SdClass.DetectRemovableDrive;

--- a/WiiLink-Patcher-CLI/patch.cs
+++ b/WiiLink-Patcher-CLI/patch.cs
@@ -41,7 +41,7 @@ public class PatchClass
             DownloadFile($"https://github.com/fishguy6564/AnyGlobe-Changer/releases/download/1.0/AnyGlobe.Changer.zip", 
                 Path.Join(appPath, "AGC.zip"), 
                 "AnyGlobe_Changer");
-            ZipFile.ExtractToDirectory(Path.Join(appPath, "AGC.zip"), "./");
+            ZipFile.ExtractToDirectory(Path.Join(appPath, "AGC.zip"), Path.Join("WiiLink"));
             Directory.Delete(appPath, true);
         }
     }


### PR DESCRIPTION
I made a mistake when changing the file paths and AnyGlobe Changer isn't properly saved to the "WiiLink" subdirectory, this PR fixes that. Sorry for the inconvenience.